### PR TITLE
fix: missing react rules file definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-[![npm-version](https://badge.fury.io/js/%40wetransfer%2Feslint-config-wetransfer.svg)](https://badge.fury.io/js/%40wetransfer%2Feslint-config-wetransfer.svg)
+[![npm-version](https://badge.fury.io/js/%40wetransfer%2Feslint-config-wetransfer.svg)](https://www.npmjs.com/package/@wetransfer/eslint-config-wetransfer)
 [![Build Status](https://travis-ci.org/WeTransfer/eslint-config-wetransfer.svg?branch=master)](https://travis-ci.org/WeTransfer/eslint-config-wetransfer)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 
 # WeTransfer ESLint Config
 This package provides WeTransfer's base `.eslintrc` as an extensible shared config. We also provide some React rules as a separate configuration.
-It is eslint@4+-compatible and maintained by the friendly folks at WeTransfer. 
+It is eslint@4+-compatible and maintained by the friendly folks at WeTransfer.
 
-## Installation 
-1. Install this config package and ESLint: `$ npm install --save-dev eslint @wetransfer/eslint-config-wetransfer`.
+## Installation
+1. Install this config package and ESLint: `npm install --save-dev eslint @wetransfer/eslint-config-wetransfer`.
 2. Add `"extends": "@wetransfer/wetransfer"` to your `.eslintrc`.
-3. Add `"extends": "@wetransfer/wetransfer/react"` to your `.eslintrc` if you want to make use of our React specific rules.
+3. Add `"extends": "@wetransfer/wetransfer/react"` to your `.eslintrc` if you want to make use of our React specific rules. In that case, please install `eslint-plugin-react` as well:
+  * `npm install --save-dev eslint-plugin-react`
 
 ## Which rules do we define?
 Please take a look to the source code of [index.js](https://github.com/WeTransfer/eslint-config-wetransfer/blob/master/index.js), which lists every ESLint rule provided by this configuration.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "main": "index.js",
   "files": [
-    "index.js"
+    "index.js",
+    "react.js"
   ],
   "author": "WeTransfer",
   "repository": {


### PR DESCRIPTION
The new react rules file was not part of the `package.json`, and for instance, not published to npm.