### PR TITLE
Fix: Always use curly braces

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = {
     'keyword-spacing': 'error',
 
     // Spaces in object definitions
-    'object-curly-spacing': 'error',
+    'object-curly-spacing': ['error', 'always'],
 
     // Arrow function arguments parenthesis
     'arrow-parens': 'error',

--- a/spec/index.js
+++ b/spec/index.js
@@ -13,7 +13,7 @@ const repoFiles = [
 const eslintOpts = {
   useEslintrc: false,
   envs: ['node', 'es6'],
-  parserOptions: {ecmaVersion: 2017},
+  parserOptions: { ecmaVersion: 2017 },
   rules: config.rules
 };
 


### PR DESCRIPTION
Accidentally we shipped the eslint rule object `object-curly-spacing` with the default setting `never`. This isn't expected behavior and should be set to `always`. 

Closes #28