### PR TITLE
Enable comma-dangle

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,32 +6,32 @@ module.exports = {
       2,
       {
         // Indentation level for case clauses in switch statements
-        'SwitchCase': 1
-      }
+        'SwitchCase': 1,
+      },
     ],
 
     // Unix style line breaks
     'linebreak-style': [
       'error',
-      'unix'
+      'unix',
     ],
 
     // Be consistent when using quotes on property names
     'quote-props': [
       'error',
-      'consistent'
+      'consistent',
     ],
 
     // Use single quotes
     'quotes': [
       'error',
-      'single'
+      'single',
     ],
 
     // Always end a line with a semicolon
     'semi': [
       'error',
-      'always'
+      'always',
     ],
 
     // Spaces between functions and parenthesis
@@ -40,8 +40,8 @@ module.exports = {
       {
         'anonymous': 'never',
         'named': 'never',
-        'asyncArrow': 'always'
-      }
+        'asyncArrow': 'always',
+      },
     ],
 
     // Function declaration styles
@@ -49,8 +49,8 @@ module.exports = {
       'error',
       'declaration',
       {
-        'allowArrowFunctions': true
-      }
+        'allowArrowFunctions': true,
+      },
     ],
 
     // Confusion with comparisons and arrow functions
@@ -72,14 +72,14 @@ module.exports = {
     'no-param-reassign': [
       'off',
       {
-        'props': true
-      }
+        'props': true,
+      },
     ],
 
     // Use type-safe equality operators.
     'eqeqeq': [
       'error',
-      'always'
+      'always',
     ],
 
     // Prevent typing useless code
@@ -104,8 +104,8 @@ module.exports = {
     'no-unused-expressions': [
       'error',
       {
-        'allowShortCircuit': true
-      }
+        'allowShortCircuit': true,
+      },
     ],
 
     // Disallow early use of variables and functions
@@ -150,8 +150,8 @@ module.exports = {
       {
         'max': 1,
         'maxEOF': 1,
-        'maxBOF': 0
-      }
+        'maxBOF': 0,
+      },
     ],
 
     // Require curly braces
@@ -167,6 +167,6 @@ module.exports = {
     'no-return-assign': 'error',
 
     // Require variable declarations to be at the top of their scope
-    'vars-on-top': 'error'
-  }
+    'vars-on-top': 'error',
+  },
 };

--- a/index.js
+++ b/index.js
@@ -123,11 +123,14 @@ module.exports = {
     // Consistent brace style for blocks.
     'brace-style': 'error',
 
-    // Disallow trailing commas
-    'comma-dangle': [
-      'error',
-      'never'
-    ],
+    // Allow dangling commas to improve git diffs
+    'comma-dangle': ['error', {
+      'arrays': 'always-multiline',
+      'objects': 'always-multiline',
+      'imports': 'always-multiline',
+      'exports': 'always-multiline',
+      'functions': 'ignore',
+    }],
 
     // Disallow Use of Alert
     'no-alert': 'error',

--- a/react.js
+++ b/react.js
@@ -27,6 +27,6 @@ module.exports = {
     'react/prefer-stateless-function': 'warn',
 
     // Components without children should be self-closing to avoid unnecessary extra closing tag.
-    'react/self-closing-comp': 'error'
-  }
+    'react/self-closing-comp': 'error',
+  },
 };

--- a/spec/index.js
+++ b/spec/index.js
@@ -6,7 +6,7 @@ const config = require('../');
 const repoFiles = [
   'index.js',
   'react.js',
-  'spec/index.js'
+  'spec/index.js',
 ];
 
 // esLint options
@@ -14,7 +14,7 @@ const eslintOpts = {
   useEslintrc: false,
   envs: ['node', 'es6'],
   parserOptions: { ecmaVersion: 2017 },
-  rules: config.rules
+  rules: config.rules,
 };
 
 // Run linter


### PR DESCRIPTION
Dear @WeTransfer/frontend -ers

I would like to propose this change.
https://eslint.org/docs/rules/comma-dangle

<img width="262" alt="image" src="https://user-images.githubusercontent.com/1935066/43718962-a3731f3c-998c-11e8-978f-f6ba6d0df351.png">

As you can see it will make our git-diffs much more clear.
