### PR TITLE
feat: allow function references before function declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,8 +108,13 @@ module.exports = {
       },
     ],
 
-    // Disallow early use of variables and functions
-    'no-use-before-define': 'error',
+    // Disallow early use of variables. Function "hoisting" declaration is allowed.
+    'no-use-before-define': [
+      'error',
+      {
+        'functions': false,
+      },
+    ],
 
     // Disallow unnecessary constructor
     'no-useless-constructor': 'error',


### PR DESCRIPTION
## Proposed changes

Allow function references before function declaration, for better code readability. This will allow to write code in a more natural way, where it can be read from top to bottom, like:

```js
function uploadFile() {
  uploadChunksAndFinalize();
}

function uploadChunksAndFinalize() {
  createChunksForFile();
}

function createChunksForFile() {
  createChunk();
}

function createChunk() {
}
```

## Types of changes

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/eslint-config-wetransfer/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules
